### PR TITLE
fix: normalize trivy cache path

### DIFF
--- a/actions/trivy-scan/action.yml
+++ b/actions/trivy-scan/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Cache Trivy vulnerability database
       uses: actions/cache@v5
       with:
-        path: ~/.cache/trivy
+        path: ${{ github.workspace }}/.trivy-cache
         key: trivy-db-${{ runner.os }}-${{ github.run_id }}
         restore-keys: trivy-db-${{ runner.os }}-
 
@@ -39,7 +39,7 @@ runs:
         scan-type: 'fs'
         scan-ref: ${{ inputs.scan-ref }}
         scanners: 'secret'
-        cache-dir: ~/.cache/trivy
+        cache-dir: ${{ github.workspace }}/.trivy-cache
         format: 'table'
 
     - name: Scan for vulnerabilities
@@ -51,5 +51,5 @@ runs:
         severity: ${{ inputs.severity }}
         exit-code: ${{ inputs.exit-code }}
         ignore-unfixed: ${{ inputs.ignore-unfixed }}
-        cache-dir: ~/.cache/trivy
+        cache-dir: ${{ github.workspace }}/.trivy-cache
         format: 'table'


### PR DESCRIPTION
## 📝 Description
<!-- Explain what you did. Why is this change necessary? What problem does it solve? -->
<!-- Add link or number of the Shortcut ticket, if not in the branch name. -->

This should eliminate the warning when the Trivy can is being run

> Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.

by normalizing the path with respect to the workspace in question.

## Scope of Change
<!-- Select the type of change (put an x in the brackets) -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no behavior change)
- [ ] Documentation
- [x] Configuration Change (Infrastructure, Env vars, etc.)

## Test Plan
<!-- How did you verify this change? Provide instructions so reviewers can reproduce. -->
<!-- Attach screenshots or terminal output if applicable. -->

Need to run the scan in GitHub Actions. 

## Impact & Risks
<!-- Does this change require database migrations? API version bumps? -->
<!-- Is this a breaking change? -->

This should fix the caching warning for the scan results.

## Verification
- [x] I have performed a self-review of my code.
~- [ ] I have added/updated tests for this change.~
~- [ ] I have commented hard-to-understand areas.~
- [x] The code/service runs locally as expected.
