### PR TITLE
2809/exclude-storybook-files-from-pr-size-checks

### DIFF
--- a/actions/pr-size-check/action.yml
+++ b/actions/pr-size-check/action.yml
@@ -1,11 +1,15 @@
 name: PR Size Check
-description: Fails if a pull request exceeds the maximum allowed lines changed (additions + deletions).
+description: Fails if a pull request exceeds the maximum allowed additions, excluding dynamically specified file patterns.
 
 inputs:
   max_lines_changed:
-    description: Maximum total lines changed (additions + deletions) before the check fails.
+    description: Maximum total additions before the check fails.
     required: false
     default: "1200"
+  exclude_pattern:
+    description: Regex pattern of filenames to exclude from the additions count (e.g., '\.stories\.' or '\.stories\.|\\.svg$')
+    required: false
+    default: '\.stories\.'
   github_token:
     description: GitHub token used to fetch PR diff stats.
     required: false
@@ -18,7 +22,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        MAX_LINES: ${{ inputs.max_lines_changed }}
+        MAX_ADDITIONS: ${{ inputs.max_lines_changed }}
+        EXCLUDE_PATTERN: ${{ inputs.exclude_pattern }}
       run: |
         PR_NUMBER="${{ github.event.pull_request.number }}"
 
@@ -27,18 +32,24 @@ runs:
           exit 1
         fi
 
-        STATS=$(gh api repos/${{ github.repository }}/pulls/"$PR_NUMBER" --jq '{additions, deletions}')
-        ADDITIONS=$(echo "$STATS" | jq '.additions')
-        DELETIONS=$(echo "$STATS" | jq '.deletions')
-        TOTAL=$((ADDITIONS))
+        # Fetch all files changed in the PR (using --paginate to handle large PRs safely)
+        FILES_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/files" --paginate)
 
-        echo "Additions: $ADDITIONS"
-        echo "Deletions: $DELETIONS"
-        echo "Total lines changed: $TOTAL"
-        echo "Max allowed additions: $MAX_LINES"
+        # Use jq to filter out files matching the EXCLUDE_PATTERN and sum the remaining additions
+        # We pass EXCLUDE_PATTERN safely as a jq variable using --arg
+        ADDITIONS=$(echo "$FILES_JSON" | jq -s --arg pattern "$EXCLUDE_PATTERN" '
+          flatten | 
+          map(select($pattern == "" or (.filename | test($pattern) | not))) | 
+          map(.additions) | 
+          add // 0
+        ')
 
-        if [ "$TOTAL" -gt "$MAX_LINES" ]; then
-          echo "::error::PR has $TOTAL additions, which exceeds the limit of $MAX_LINES. Please break this PR into smaller changes."
+        echo "Excluded pattern: $EXCLUDE_PATTERN"
+        echo "Total additions (filtered): $ADDITIONS"
+        echo "Max allowed additions: $MAX_ADDITIONS"
+
+        if [ "$ADDITIONS" -gt "$MAX_ADDITIONS" ]; then
+          echo "::error::PR has $ADDITIONS additions, which exceeds the limit of $MAX_ADDITIONS. Please break this PR into smaller changes."
           exit 1
         fi
 


### PR DESCRIPTION
## 📝 Description
https://app.shortcut.com/neralake/story/2809/exclude-storybook-files-from-pr-size-checks

We want to filter certain files out of our PR size check as they do not contribute to the product directly and are instead more like dev tools. One of the largest such files are .stories storybook files, so we start with those, but this is easy to extend to other file types as well.

The main change here is the fact that we can no longer rely on github providing the number of lines added, and instead must first get all of the changed files with the lines added in each, filter out the files that match the pattern, and only then add them manually ourselves.

I also noticed that the description does not match the functionality. I am guessing sometime in the past we used to track number of total lines changed, but excluded tracking removals so as to not punish developers that clean dead code. I did keep `max_lines_changed` just to avoid having to change that everywhere.

## Scope of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code improvement with no behavior change)
- [ ] Documentation
- [x] Configuration Change (Infrastructure, Env vars, etc.)

## Test Plan
N/A

## Impact & Risks
Hypothetically, any files with the `.stories.` pattern will be excluded. Plus, if the logic is incorrect, then the script may fail in a pretty obvious way, and can be easily rolled back or fixed if necessary.

## Verification
- [x] I have performed a self-review of my code.
- [ ] I have added/updated tests for this change.
- [ ] I have commented hard-to-understand areas.
- [ ] The code/service runs locally as expected.
